### PR TITLE
docs: approve v2 scaffold architecture

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -10,13 +10,29 @@
 
 ## Current phase
 
-**PRE-DEVELOPMENT / PHASE 0**
+**PHASE 0 — AUDIT AND FOUNDATION PREPARATION**
 
-The product vision, architecture, content model, low-poly Three.js preview, quality strategy and controlled multi-agent workflow are documented.
+The product vision, architecture, content model, low-poly Three.js preview, quality strategy and controlled multi-agent workflow are documented. Scaffold decisions are accepted.
+
+## Approved technical baseline
+
+- Laravel 13 / PHP 8.3+
+- PostgreSQL
+- Redis
+- Blade SSR public portfolio
+- Vue 3 + TypeScript + Inertia dashboard
+- vanilla Three.js + TypeScript preview/fullscreen module
+- npm
+- PHPUnit
+- one private administrator initially
+- Docker Compose locally
+- OVH VPS + Docker for production
+
+See `docs/architecture/decisions/ADR-005-scaffold-baseline.md`.
 
 ## Current objective
 
-Prepare a verified Laravel 13 modular foundation without losing the existing React/TypeScript v2 prototype.
+Audit the existing React/TypeScript v2 prototype, then build a verified Laravel 13 modular foundation without losing useful frontend or 3D work.
 
 ## Source of truth
 
@@ -34,17 +50,20 @@ Prepare a verified Laravel 13 modular foundation without losing the existing Rea
 
 ## Immediate next steps
 
-1. Audit the existing v2 React/TypeScript prototype.
-2. Decide which prototype assets and interactions are retained.
-3. Scaffold the Laravel 13 modular application.
-4. Add Docker, MySQL, Redis and Nginx local services.
-5. Configure quality gates and CI.
-6. Implement private dashboard authentication.
-7. Implement the public portfolio CMS before the final Three.js room.
+1. Complete PORT-000: audit the existing React/TypeScript/Three.js prototype.
+2. Start PORT-002: scaffold Laravel 13 after the audit identifies retained/migrated prototype assets.
+3. Add Docker services: Nginx, PostgreSQL, Redis, queue worker, scheduler and Mailpit.
+4. Configure Pint, Larastan/PHPStan, PHPUnit, ESLint, Stylelint, build checks and CI.
+5. Implement the single-admin private authentication boundary.
+6. Implement the public portfolio CMS and HTML landing page.
+7. Integrate a temporary low-poly Three.js scene before final Blender assets.
 
-## Blocking decisions
+## Non-blocking parallel work
 
-See `docs/readiness/open-decisions.md`.
+- Blender/avatar reference preparation;
+- design references and captures;
+- deep analysis of featured project repositories;
+- confirmation of public contact/CV/activity visibility.
 
 ## Update rule
 

--- a/docs/architecture/decisions/ADR-001-modular-monolith.md
+++ b/docs/architecture/decisions/ADR-001-modular-monolith.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -10,7 +10,9 @@ The platform contains public CMS content, project management, integrations, demo
 
 ## Decision
 
-Use one Laravel application with explicit modules and contracts. Extract a service only when operational or domain evidence justifies it.
+Use one Laravel 13 application with explicit modules and contracts. Extract a service only when operational or domain evidence justifies it.
+
+The initial platform will use PostgreSQL, Redis, queues and the Laravel scheduler inside one deployable application. Module ownership and contracts remain strict even though deployment is unified.
 
 ## Consequences
 
@@ -18,4 +20,5 @@ Use one Laravel application with explicit modules and contracts. Extract a servi
 - one deployment unit;
 - simpler transactions;
 - strict module boundaries remain mandatory;
-- cross-module coupling must be monitored.
+- cross-module coupling must be monitored;
+- service extraction remains possible after real operational evidence exists.

--- a/docs/architecture/decisions/ADR-002-frontend-rendering.md
+++ b/docs/architecture/decisions/ADR-002-frontend-rendering.md
@@ -2,24 +2,28 @@
 
 ## Status
 
-Proposed — requires final confirmation before scaffolding
+Accepted
 
 ## Context
 
-The public portfolio needs SEO, accessibility and fast first render. The dashboard needs a richer application interface. The 3D section requires Three.js but should not dictate the whole frontend stack.
+The public portfolio needs SEO, accessibility and a fast first render. The private dashboard needs a richer application interface. The 3D section requires Three.js but must not dictate the whole frontend stack.
 
 ## Decision
 
-Recommended approach:
+Use:
 
-- Laravel SSR/Blade for the public landing page and case-study content;
-- Vue 3 + TypeScript for dashboard-rich interactions, either through Inertia or a clearly isolated SPA area;
-- vanilla Three.js + TypeScript mounted as an isolated public-page module;
-- Vite for bundling and code splitting.
+- Laravel Blade/server-rendered HTML for the public landing page, case studies and essential portfolio content;
+- Vue 3 + TypeScript with Inertia for the private dashboard and rich authenticated interactions;
+- vanilla Three.js + TypeScript mounted as an isolated, lazy-loaded public-page module;
+- Vite for bundling, code splitting and shared frontend assets;
+- shared design tokens across Blade, Vue and Three.js overlays.
+
+The existing React/TypeScript prototype must be audited before useful UI or Three.js work is migrated. React is not retained as a platform dependency unless PORT-000 identifies a specific isolated component whose migration cost is unjustified.
 
 ## Consequences
 
-- public content remains indexable;
-- Three.js loads independently;
-- dashboard can use a component architecture;
-- the project must define shared design tokens across Blade and Vue.
+- public content remains indexable and accessible;
+- the dashboard keeps a component-based frontend without requiring a separate SPA deployment;
+- Three.js loads independently and can fail without breaking core content;
+- shared design tokens and API contracts must be maintained across Blade and Vue;
+- the React prototype will be classified and migrated deliberately rather than deleted blindly.

--- a/docs/architecture/decisions/ADR-004-multi-agent-delivery.md
+++ b/docs/architecture/decisions/ADR-004-multi-agent-delivery.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 
@@ -12,9 +12,20 @@ The project has parallel domains: backend, dashboard, public UI, Three.js, infra
 
 Use a parent/orchestrator agent with specialized subagents. Parallelize read-heavy tasks and independent work. Use separate Git worktrees for simultaneous code-writing agents. The orchestrator owns integration, cross-module decisions and final quality gates.
 
+Initial operating limits:
+
+- maximum six total agent threads;
+- maximum nesting depth one;
+- maximum two concurrent write agents;
+- one explicit owner per file path;
+- no agent merges its own work into `main`;
+- GitHub Issues define scope and acceptance criteria;
+- Pull Requests contain implementation evidence.
+
 ## Consequences
 
 - faster exploration and review;
 - higher token use than single-agent workflows;
 - explicit task boundaries and handoff format required;
-- no two write agents may own the same files simultaneously.
+- no two write agents may own the same files simultaneously;
+- the orchestrator remains accountable for architecture, integration and release quality.

--- a/docs/architecture/decisions/ADR-005-scaffold-baseline.md
+++ b/docs/architecture/decisions/ADR-005-scaffold-baseline.md
@@ -1,0 +1,37 @@
+# ADR-005: Portfolio v2 Scaffold Baseline
+
+## Status
+
+Accepted
+
+## Context
+
+Laravel scaffolding requires stable decisions for persistence, package management, testing, authentication and deployment. Leaving these choices implicit would create inconsistent agent output and unnecessary rework.
+
+## Decision
+
+Use the following baseline for portfolio v2:
+
+- **Framework:** Laravel 13 on PHP 8.3+;
+- **Database:** PostgreSQL as the primary relational database;
+- **Cache and queues:** Redis;
+- **JavaScript package manager:** npm;
+- **PHP test framework:** PHPUnit;
+- **Public rendering:** Laravel Blade/server-rendered HTML;
+- **Dashboard frontend:** Vue 3 + TypeScript with Inertia;
+- **3D runtime:** vanilla Three.js + TypeScript as an isolated lazy-loaded module;
+- **Authentication:** one private administrator in the initial release, with authorization boundaries designed for later multi-user RBAC;
+- **Local environment:** Docker Compose with Nginx, PostgreSQL, Redis, queue worker, scheduler and Mailpit;
+- **Production target:** OVH VPS with Docker, Nginx, PostgreSQL, Redis, workers, scheduler, monitoring and backups;
+- **Asset strategy:** private Blender sources separated from optimized public GLB/poster assets;
+- **Legacy prototype:** audit first, migrate useful parts, then archive or remove only with documented evidence.
+
+## Consequences
+
+- Codex can scaffold against one unambiguous stack;
+- PostgreSQL-specific behavior must be covered by tests and local containers;
+- the first authentication implementation remains intentionally narrow;
+- RBAC-ready authorization boundaries must not be confused with immediate multi-user administration;
+- deployment automation must target OVH VPS/Docker without embedding production credentials;
+- npm lockfiles become part of reproducible builds;
+- PHPUnit remains the canonical PHP test runner.

--- a/docs/coordination/decision-log.md
+++ b/docs/coordination/decision-log.md
@@ -7,6 +7,10 @@
 | 2026-07-11 | Promote v2 preparation to `main` | Confirmed | User decision |
 | 2026-07-11 | Portfolio remains HTML-first with one low-poly 3D preview/fullscreen section | Confirmed | ADR-003 |
 | 2026-07-11 | Blender work proceeds in parallel and follows a formal GLB handoff | Confirmed | Blender handoff contract |
-| 2026-07-11 | Use controlled multi-agent development with one orchestrator and isolated write ownership | Proposed | ADR-004 |
-| 2026-07-11 | Laravel modular monolith for the final platform | Proposed | ADR-001 |
-| 2026-07-11 | Blade public pages + Vue dashboard + vanilla Three.js | Proposed | ADR-002 |
+| 2026-07-11 | Use controlled multi-agent development with one orchestrator and isolated write ownership | Confirmed | ADR-004 |
+| 2026-07-11 | Use a Laravel 13 modular monolith | Confirmed | ADR-001 |
+| 2026-07-11 | Use Blade SSR for public pages, Vue 3 + TypeScript + Inertia for dashboard, and vanilla Three.js + TypeScript for 3D | Confirmed | ADR-002 |
+| 2026-07-11 | Use PostgreSQL, Redis, npm and PHPUnit | Confirmed | ADR-005 |
+| 2026-07-11 | Start with one private administrator and prepare authorization boundaries for later RBAC | Confirmed | ADR-005 |
+| 2026-07-11 | Target OVH VPS with Docker, Nginx, workers, scheduler, monitoring and backups | Confirmed | ADR-005 |
+| 2026-07-11 | Audit the existing React prototype before migration or removal | Confirmed | PORT-000 / ADR-005 |

--- a/docs/readiness/open-decisions.md
+++ b/docs/readiness/open-decisions.md
@@ -1,32 +1,41 @@
 # Open Decisions
 
-## Blocking before Laravel scaffolding
+## Scaffold decisions — resolved
 
-1. Confirm public rendering: Blade/server-rendered pages.
-2. Confirm dashboard frontend: Vue 3 + TypeScript, and whether to use Inertia.
-3. Confirm Three.js runtime: vanilla Three.js + TypeScript rather than React Three Fiber.
-4. Choose database: MySQL or PostgreSQL.
-5. Choose JavaScript package manager: npm or pnpm.
-6. Choose PHP test framework: PHPUnit or Pest.
-7. Choose initial authentication scope: one private administrator or full multi-user RBAC.
-8. Confirm target hosting and deployment model.
-9. Confirm whether the existing React prototype is archived after useful pieces are migrated.
+The following baseline is accepted for portfolio v2:
 
-## Blocking before final visual implementation
+1. Public rendering: Laravel Blade/server-rendered pages.
+2. Dashboard frontend: Vue 3 + TypeScript with Inertia.
+3. Three.js runtime: vanilla Three.js + TypeScript.
+4. Database: PostgreSQL.
+5. JavaScript package manager: npm.
+6. PHP test framework: PHPUnit.
+7. Initial authentication: one private administrator, with boundaries prepared for later RBAC.
+8. Hosting: OVH VPS with Docker, Nginx, PostgreSQL, Redis, workers, scheduler, monitoring and backups.
+9. Existing React prototype: audit first under PORT-000, migrate useful elements, then archive/remove only with documented evidence.
+
+See `docs/architecture/decisions/ADR-005-scaffold-baseline.md`.
+
+## Still blocking final visual implementation
 
 - final color palette;
 - typography;
-- portfolio languages;
-- featured-project order;
+- public portfolio language strategy: French, English or bilingual;
+- final featured-project order;
 - downloadable CV choice;
-- public/private GitHub and GitLab activity policy.
+- public/private GitHub and GitLab activity policy;
+- approved landing-page and dashboard mockups.
 
-## Blocking before final 3D asset production
+## Still blocking final 3D asset production
 
-- current photo references;
+- current photo references for avatar likeness;
 - avatar hairstyle, facial hair, glasses and outfit;
 - preferred low-poly style;
 - room layout reference;
 - asset source strategy: self-created, commissioned or licensed assets;
-- text-only greeting for first release or future audio;
-- final asset budgets after prototype profiling.
+- confirmation that the first release uses text-only greeting;
+- final asset budgets after temporary-scene profiling.
+
+## Not blocking Phase 0 scaffolding
+
+The visual and final Blender decisions above do not block PORT-000 or PORT-002. Temporary assets and placeholders must be used until the final handoff is approved.

--- a/docs/readiness/pre-development-checklist.md
+++ b/docs/readiness/pre-development-checklist.md
@@ -8,7 +8,7 @@
 - [x] Codex agent configuration prepared.
 - [x] Multi-agent workflow prepared.
 - [x] GitHub issue and PR templates prepared.
-- [ ] Promote prepared v2 commit to `main`.
+- [x] Prepared v2 commit promoted to `main`.
 - [ ] Configure branch protection for `main`.
 
 ## Product
@@ -22,11 +22,13 @@
 
 ## Architecture
 
-- [x] Modular-monolith proposal documented.
-- [x] Frontend-rendering proposal documented.
+- [x] Modular monolith accepted.
+- [x] Blade + Vue/Inertia + vanilla Three.js frontend strategy accepted.
+- [x] PostgreSQL, npm, PHPUnit, single-admin and OVH/Docker baseline accepted.
 - [x] Three.js boundary accepted.
 - [x] 3D asset handoff documented.
-- [ ] Resolve blocking scaffold decisions.
+- [x] Controlled multi-agent delivery accepted.
+- [ ] Complete PORT-000 prototype audit.
 
 ## Content
 
@@ -40,12 +42,14 @@
 
 - [ ] Laravel 13 scaffold.
 - [ ] Docker Compose.
-- [ ] Database and Redis.
+- [ ] PostgreSQL and Redis.
 - [ ] Nginx local configuration.
+- [ ] Queue worker and scheduler services.
 - [ ] Mailpit.
 - [ ] `.env.example`.
 - [ ] quality scripts.
 - [ ] CI workflow.
+- [ ] branch protection and required checks.
 
 ## 3D preparation
 
@@ -55,3 +59,4 @@
 - [ ] Low-poly style approved.
 - [ ] Room blockout approved.
 - [ ] Temporary GLB integrated and profiled.
+- [ ] Final Blender asset handoff validated.


### PR DESCRIPTION
Closes #4

## Summary

Records the approved portfolio v2 scaffold baseline:

- Laravel 13 modular monolith
- Blade SSR public portfolio
- Vue 3 + TypeScript + Inertia dashboard
- vanilla Three.js + TypeScript low-poly preview/fullscreen module
- PostgreSQL + Redis
- npm
- PHPUnit
- one private administrator initially
- OVH VPS + Docker deployment target
- controlled multi-agent delivery

## Documentation updated

- ADR-001 accepted
- ADR-002 accepted
- ADR-004 accepted
- ADR-005 added
- open scaffold decisions resolved
- project status updated
- readiness checklist updated
- decision log updated

## Validation

Documentation-only change. No application runtime changed.
